### PR TITLE
feat(api): proxy priority, source, timeout support

### DIFF
--- a/ollama_queue/api.py
+++ b/ollama_queue/api.py
@@ -256,10 +256,21 @@ def create_app(db: Database) -> FastAPI:
 
     @app.post("/api/generate")
     async def proxy_generate(body: dict = Body(...)):
-        """Forward a generate request to Ollama, serializing through the queue."""
+        """Forward a generate request to Ollama, serializing through the queue.
+
+        Queue-specific fields (extracted from body, not forwarded to Ollama):
+          _priority: int (default 0) — job priority (lower = higher priority)
+          _source: str (default "proxy") — caller identifier for history/debugging
+          _timeout: int (default 120) — request timeout in seconds
+        """
         state = db.get_daemon_state()
         if state and state.get("state") == "paused_manual":
             raise HTTPException(status_code=503, detail="Queue is manually paused")
+
+        # Extract queue-specific fields before forwarding to Ollama
+        priority = body.pop("_priority", 0)
+        source = body.pop("_source", "proxy")
+        req_timeout = body.pop("_timeout", 120)
 
         body["stream"] = False  # MVP: no streaming
 
@@ -281,14 +292,14 @@ def create_app(db: Database) -> FastAPI:
         job_id = db.submit_job(
             command="proxy:/api/generate",
             model=model,
-            priority=0,
-            timeout=120,
-            source="proxy",
+            priority=priority,
+            timeout=req_timeout,
+            source=source,
         )
         db.start_job(job_id)
 
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0)) as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(float(req_timeout))) as client:
                 resp = await client.post(f"{OLLAMA_URL}/api/generate", json=body)
                 result = resp.json()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -244,3 +244,87 @@ def test_get_models_catalog(client):
     data = resp.json()
     assert "curated" in data
     assert len(data["curated"]) > 0
+
+
+class TestProxyPriority:
+    """Proxy /api/generate accepts _priority, _source, _timeout fields."""
+
+    def _mock_httpx_client(self, response_data):
+        from unittest.mock import AsyncMock, MagicMock
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = response_data
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        return mock_client
+
+    def test_priority_and_source_recorded_in_job(self, client):
+        from unittest.mock import patch
+
+        mock_client = self._mock_httpx_client({"response": "hello", "done": True})
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            resp = client.post(
+                "/api/generate",
+                json={
+                    "model": "test-model",
+                    "prompt": "hello",
+                    "_priority": 1,
+                    "_source": "eval-generate",
+                    "_timeout": 300,
+                },
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["response"] == "hello"
+
+        history = client.get("/api/history?limit=1").json()
+        assert len(history) >= 1
+        job = history[0]
+        assert job["priority"] == 1
+        assert job["source"] == "eval-generate"
+        assert job["timeout"] == 300
+
+    def test_defaults_without_queue_fields(self, client):
+        from unittest.mock import patch
+
+        mock_client = self._mock_httpx_client({"response": "ok", "done": True})
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            resp = client.post(
+                "/api/generate",
+                json={"model": "test-model", "prompt": "hello"},
+            )
+
+        assert resp.status_code == 200
+
+        history = client.get("/api/history?limit=1").json()
+        job = history[0]
+        assert job["priority"] == 0
+        assert job["source"] == "proxy"
+        assert job["timeout"] == 120
+
+    def test_queue_fields_not_forwarded_to_ollama(self, client):
+        from unittest.mock import patch
+
+        mock_client = self._mock_httpx_client({"response": "ok", "done": True})
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            client.post(
+                "/api/generate",
+                json={
+                    "model": "test-model",
+                    "prompt": "hello",
+                    "_priority": 1,
+                    "_source": "eval",
+                },
+            )
+
+        call_args = mock_client.post.call_args
+        forwarded_body = call_args.kwargs.get("json", call_args[1].get("json", {}))
+        assert "_priority" not in forwarded_body
+        assert "_source" not in forwarded_body
+        assert "_timeout" not in forwarded_body


### PR DESCRIPTION
## Summary

- Proxy `/api/generate` now accepts `_priority`, `_source`, `_timeout` in the request body
- Fields are extracted before forwarding to Ollama (underscore prefix prevents collision)
- Enables callers like lessons-db eval pipeline to set `_priority: 1` for batch jobs
- Backward compatible — omitting fields defaults to `priority=0, source="proxy", timeout=120`

## Test plan
- [x] 229 tests pass (3 new: priority recorded, defaults correct, fields not forwarded)
- [x] Existing proxy behavior unchanged when no `_` fields provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)