### PR TITLE
feat(spa): sync dashboard with PR2-PR4 backend features

### DIFF
--- a/ollama_queue/dashboard/spa/src/components/CurrentJob.jsx
+++ b/ollama_queue/dashboard/spa/src/components/CurrentJob.jsx
@@ -39,6 +39,7 @@ export default function CurrentJob({ daemon, currentJob, latestHealth, settings 
 
   const hp = latestHealth || {};
   const isStalled = isRunning && currentJob && !!currentJob.stall_detected_at;
+  const burstRegime = daemon.burst_regime || 'unknown';
 
   return (
     <div class="t-frame" data-label="Current"
@@ -64,6 +65,10 @@ export default function CurrentJob({ daemon, currentJob, latestHealth, settings 
                   ⚠ stalled
                 </span>
               )}
+              {/* Burst regime badge — shows traffic pattern detected by burst detector.
+               *  steady=normal, burst=high-activity surge, trough=quiet window, unknown=no data yet.
+               *  Helps decide whether to hold off submitting more work (burst) or pile it on (trough). */}
+              <BurstBadge regime={burstRegime} />
             </div>
             <div class="flex items-center gap-2 flex-wrap">
               <span class="data-mono" style="font-size: var(--type-label); color: var(--text-secondary);">
@@ -114,6 +119,34 @@ export default function CurrentJob({ daemon, currentJob, latestHealth, settings 
         </div>
       )}
     </div>
+  );
+}
+
+// What it shows: A small colored label for the current traffic burst regime:
+//   burst (orange), trough (blue), steady (muted green), unknown (grey).
+// Decision it drives: Quick visual cue — burst means the queue is under pressure,
+//   trough means it's a good time to submit batch work.
+const REGIME_STYLE = {
+  burst:   { color: '#f97316', border: '#f97316', bg: 'rgba(249,115,22,0.1)' },
+  trough:  { color: '#60a5fa', border: '#60a5fa', bg: 'rgba(96,165,250,0.1)' },
+  steady:  { color: 'var(--status-healthy)', border: 'var(--status-healthy)', bg: 'rgba(74,222,128,0.08)' },
+  unknown: { color: 'var(--text-tertiary)', border: 'var(--border-subtle)', bg: 'transparent' },
+};
+
+function BurstBadge({ regime }) {
+  if (!regime || regime === 'unknown') return null;
+  const style = REGIME_STYLE[regime] || REGIME_STYLE.unknown;
+  return (
+    <span style={{
+      fontSize: 'var(--type-label)',
+      color: style.color,
+      background: style.bg,
+      padding: '1px 6px',
+      borderRadius: '3px',
+      border: `1px solid ${style.border}`,
+    }}>
+      {regime}
+    </span>
   );
 }
 

--- a/ollama_queue/dashboard/spa/src/components/HistoryList.jsx
+++ b/ollama_queue/dashboard/spa/src/components/HistoryList.jsx
@@ -68,6 +68,9 @@ function HistoryRow({ job }) {
   const hasStall = !!job.stall_detected_at;
   const isExpandable = hasReason || hasStall;
   const duration = job.started_at && job.completed_at ? job.completed_at - job.started_at : null;
+  // preemption_count: how many times this job was paused mid-run for a higher-priority job.
+  // Shows as ↺N when > 0 so the user knows the job was interrupted before finishing.
+  const preempted = job.preemption_count > 0;
 
   let stallSignals = null;
   if (hasStall && job.stall_signals) {
@@ -96,6 +99,14 @@ function HistoryRow({ job }) {
             <span style="color: #f97316; margin-left: 4px;">⚠</span>
           )}
         </span>
+        {/* Preemption badge — only shown when job.preemption_count > 0.
+            Shows ↺N to indicate the job was interrupted N times by a higher-priority job. */}
+        {preempted && (
+          <span class="data-mono" title={`Preempted ${job.preemption_count}×`}
+                style="font-size: var(--type-micro); color: #f97316; white-space: nowrap;">
+            ↺{job.preemption_count}
+          </span>
+        )}
         {/* Model */}
         <span class="data-mono" style="font-size: var(--type-label); color: var(--text-secondary); max-width: 100px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
           {job.model || '--'}

--- a/ollama_queue/dashboard/spa/src/components/SettingsForm.jsx
+++ b/ollama_queue/dashboard/spa/src/components/SettingsForm.jsx
@@ -136,7 +136,74 @@ export default function SettingsForm({ settings, daemonState, onSave, onPause, o
         </div>
       </div>
 
-      {/* 7. Daemon Controls */}
+      {/* 7. Circuit Breaker */}
+      {/* What it shows: Automatic fault isolation — how many failures trigger the breaker,
+       *   and how long the daemon backs off before retrying. Prevents a broken Ollama
+       *   from causing cascading job failures.
+       * Decision it drives: Tune failure tolerance vs recovery speed. Low threshold = faster
+       *   isolation; long cooldown = more breathing room for Ollama to recover. */}
+      <div class="t-frame" data-label="Circuit Breaker">
+        <div class="flex flex-col gap-3">
+          <NumberRow label="Failure Threshold" settingKey="cb_failure_threshold" min={1} max={20} settings={settings} flashKey={flashKey} onBlur={handleBlur} />
+          <NumberRow label="Base Cooldown" settingKey="cb_base_cooldown" min={5} unit="sec" settings={settings} flashKey={flashKey} onBlur={handleBlur} />
+          <NumberRow label="Max Cooldown" settingKey="cb_max_cooldown" min={30} unit="sec" settings={settings} flashKey={flashKey} onBlur={handleBlur} />
+        </div>
+      </div>
+
+      {/* 8. Admission */}
+      {/* What it shows: Controls on what gets let into the queue — max depth before 429s,
+       *   minimum VRAM requirement per model, and CPU-offload efficiency multiplier.
+       * Decision it drives: Protect the system from queue floods. Raise max_queue_depth
+       *   if legitimate work is being rejected; lower min_model_vram_mb to allow smaller
+       *   models to run without VRAM checks. */}
+      <div class="t-frame" data-label="Admission">
+        <div class="flex flex-col gap-3">
+          <NumberRow label="Max Queue Depth" settingKey="max_queue_depth" min={1} max={500} settings={settings} flashKey={flashKey} onBlur={handleBlur} />
+          <NumberRow label="Min Model VRAM" settingKey="min_model_vram_mb" min={0} unit="MB" settings={settings} flashKey={flashKey} onBlur={handleBlur} />
+          <NumberRow label="CPU Offload Efficiency" settingKey="cpu_offload_efficiency" min={0.0} max={1.0} step="0.05" unit="×" settings={settings} flashKey={flashKey} onBlur={handleBlur} />
+        </div>
+      </div>
+
+      {/* 9. Scheduling */}
+      {/* What it shows: Shortest-Job-First tuning — how fast older jobs age up in priority
+       *   (aging factor) and how much AoI (Age of Information) urgency matters vs raw SJF.
+       * Decision it drives: If old low-priority jobs get stuck behind fast new jobs, reduce
+       *   sjf_aging_factor or increase aoi_weight to give them more urgency. */}
+      <div class="t-frame" data-label="Scheduling">
+        <div class="flex flex-col gap-3">
+          <NumberRow label="SJF Aging Factor" settingKey="sjf_aging_factor" min={60} unit="sec" settings={settings} flashKey={flashKey} onBlur={handleBlur} />
+          <NumberRow label="AoI Weight" settingKey="aoi_weight" min={0.0} max={1.0} step="0.05" settings={settings} flashKey={flashKey} onBlur={handleBlur} />
+        </div>
+      </div>
+
+      {/* 10. Preemption */}
+      {/* What it shows: Whether the daemon is allowed to pause a low-priority running job
+       *   so a critical job can run first, and the guard rails around doing so.
+       * Decision it drives: Enable preemption for latency-sensitive high-priority jobs;
+       *   tune the window and per-job cap to avoid starving any single job. */}
+      <div class="t-frame" data-label="Preemption">
+        <div class="flex flex-col gap-3">
+          <ToggleRow label="Enable Preemption" settingKey="preemption_enabled" settings={settings} flashKey={flashKey} onSave={onSave} flash={flash} />
+          <NumberRow label="Preemption Window" settingKey="preemption_window_seconds" min={10} unit="sec" settings={settings} flashKey={flashKey} onBlur={handleBlur} />
+          <NumberRow label="Max Preemptions / Job" settingKey="max_preemptions_per_job" min={0} max={10} settings={settings} flashKey={flashKey} onBlur={handleBlur} />
+        </div>
+      </div>
+
+      {/* 11. Entropy */}
+      {/* What it shows: Anomaly detection thresholds — the rolling window size and how many
+       *   standard deviations above baseline triggers a "queue entropy spike" alert, plus
+       *   whether low-priority jobs are suspended during a spike.
+       * Decision it drives: Tighten the sigma to catch subtle anomalies earlier; widen it
+       *   to reduce false-alarm noise during normal traffic variance. */}
+      <div class="t-frame" data-label="Entropy">
+        <div class="flex flex-col gap-3">
+          <NumberRow label="Alert Window" settingKey="entropy_alert_window" min={5} max={120} settings={settings} flashKey={flashKey} onBlur={handleBlur} />
+          <NumberRow label="Alert Sigma" settingKey="entropy_alert_sigma" min={0.5} max={5.0} step="0.1" unit="σ" settings={settings} flashKey={flashKey} onBlur={handleBlur} />
+          <ToggleRow label="Suspend Low-Priority on Spike" settingKey="entropy_suspend_low_priority" settings={settings} flashKey={flashKey} onSave={onSave} flash={flash} />
+        </div>
+      </div>
+
+      {/* 12. Daemon Controls */}
       <div class="t-frame" data-label="Daemon Controls">
         <div class="flex items-center gap-3">
           {isPaused ? (


### PR DESCRIPTION
## Summary

- **SettingsForm**: 5 new settings sections covering all 12 backend DEFAULTS added in PR2-PR4 (Circuit Breaker, Admission, Scheduling, Preemption, Entropy)
- **CurrentJob**: `burst_regime` badge shows daemon's traffic pattern detection (steady/burst/trough) from `daemon.burst_regime`
- **HistoryList**: `preemption_count` indicator (↺N) on job rows where jobs were preempted by higher-priority work

All settings use the existing save-on-blur + flash pattern. Each section includes layman comments per CLAUDE.md convention.

## Settings added

| Section | Keys |
|---------|------|
| Circuit Breaker | `cb_failure_threshold`, `cb_base_cooldown`, `cb_max_cooldown` |
| Admission | `max_queue_depth`, `min_model_vram_mb`, `cpu_offload_efficiency` |
| Scheduling | `sjf_aging_factor`, `aoi_weight` |
| Preemption | `preemption_enabled`, `preemption_window_seconds`, `max_preemptions_per_job` |
| Entropy | `entropy_alert_window`, `entropy_alert_sigma`, `entropy_suspend_low_priority` |

## Test plan
- [x] 367/367 Python tests pass
- [x] `npm run build` succeeds (CSS + JS)
- [ ] Verify Settings view renders all 5 new sections
- [ ] Verify `burst_regime` badge appears in Now view while job runs
- [ ] Verify `↺N` appears on preempted jobs in History

🤖 Generated with [Claude Code](https://claude.com/claude-code)