### PR TITLE
fix(eval): wire up eval run UI flow end-to-end

### DIFF
--- a/ollama_queue/api.py
+++ b/ollama_queue/api.py
@@ -1574,6 +1574,11 @@ def create_app(db: Database) -> FastAPI:
             per_cluster=int(per_cluster) if per_cluster else 4,
         )
 
+        # Persist judge_model from request body so run_eval_judge uses it instead of the setting default
+        judge_model = body.get("judge_model")
+        if judge_model and isinstance(judge_model, str):
+            _ee.update_eval_run(db, run_id, judge_model=judge_model)
+
         # Run the session in a background thread — NOT as a queued job.
         # Running as a queued job would deadlock: the daemon sets current_job_id while
         # the subprocess runs, which blocks try_claim_for_proxy() when the engine
@@ -1704,18 +1709,53 @@ def create_app(db: Database) -> FastAPI:
             ).fetchone()
             failed = failed_count["cnt"] if failed_count else 0
 
+            # Per-variant breakdown: generated count = expected judging targets per variant
+            per_variant_rows = conn.execute(
+                """SELECT variant,
+                          SUM(CASE WHEN row_type = 'generate' THEN 1 ELSE 0 END) as gen_cnt,
+                          SUM(CASE WHEN row_type = 'judge'    THEN 1 ELSE 0 END) as judge_cnt,
+                          SUM(CASE WHEN error IS NOT NULL     THEN 1 ELSE 0 END) as error_cnt
+                   FROM eval_results WHERE run_id = ? GROUP BY variant""",
+                (run_id,),
+            ).fetchall()
+
         generated = counts.get("generate", 0)
         judged = counts.get("judge", 0)
         pct = round(judged / total * 100, 1) if total > 0 else 0.0
 
+        # per_variant dict: {variant_id: {completed, total, failed}}
+        # "total" per variant = number of generate rows (each needs a judge call)
+        per_variant: dict = {}
+        for row in per_variant_rows:
+            per_variant[row["variant"]] = {
+                "completed": row["judge_cnt"],
+                "total": row["gen_cnt"],
+                "failed": row["error_cnt"],
+            }
+
+        # Determine which stage we're in to compute the "completed" counter shown in the UI
+        run_status = run["status"]
+        is_judging = run_status in ("judging",) or run.get("stage") in ("judging", "fetch_targets")
+        completed = judged if is_judging else generated
+
+        failure_rate = round(failed / total, 4) if total > 0 else 0.0
+
         return {
-            "run_id": run_id,
-            "status": run["status"],
+            # Legacy fields (keep for API compatibility)
             "generated": generated,
-            "total": total,
             "judged": judged,
-            "failed": failed,
             "pct_complete": pct,
+            # Fields the frontend progress panel reads
+            "run_id": run_id,
+            "status": run_status,
+            "stage": run.get("stage"),
+            "completed": completed,
+            "total": total,
+            "failed": failed,
+            "pct": pct,
+            "failure_rate": failure_rate,
+            "per_variant": per_variant,
+            "eta_s": None,
         }
 
     @app.post("/api/eval/runs/{run_id}/repeat")

--- a/ollama_queue/dashboard/spa/src/components/eval/ActiveRunProgress.jsx
+++ b/ollama_queue/dashboard/spa/src/components/eval/ActiveRunProgress.jsx
@@ -39,9 +39,12 @@ export default function ActiveRunProgress() {
     failure_rate = 0,
   } = activeRun;
 
-  const stageLabel = stage === 'generate'
+  // DB stage values: 'generating', 'judging', 'fetch_items', 'fetch_targets'
+  // Fall back to status when stage is null (e.g. run just started)
+  const stageContext = stage || status;
+  const stageLabel = (stageContext === 'generating' || stageContext === 'generate')
     ? EVAL_TRANSLATIONS.generating?.label ?? 'Writing principles…'
-    : stage === 'judge'
+    : (stageContext === 'judging' || stageContext === 'judge' || stageContext === 'fetch_targets')
     ? EVAL_TRANSLATIONS.judging?.label ?? 'Scoring results…'
     : 'Working…';
 

--- a/ollama_queue/dashboard/spa/src/components/eval/RunRow.jsx
+++ b/ollama_queue/dashboard/spa/src/components/eval/RunRow.jsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import { useState } from 'preact/hooks';
 import { EVAL_TRANSLATIONS } from './translations.js';
 import ResultsTable from './ResultsTable.jsx';
-import { evalActiveRun, evalSubTab, fetchEvalRuns } from '../../store.js';
+import { evalActiveRun, evalSubTab, fetchEvalRuns, startEvalPoll } from '../../store.js';
 // What it shows: A single eval run row with 3-level progressive disclosure.
 //   L1: status dot, winner config, quality score, date, item count.
 //   L2: per-variant metric table, scorer info, action buttons.
@@ -77,9 +77,12 @@ export default function RunRow({ run }) {
         setRepeatError(data.detail || 'Repeat failed');
         return;
       }
-      // Switch to runs sub-tab and set the new run as the active run
+      // Switch to runs sub-tab, set the new run as active, and start live polling
       evalSubTab.value = 'runs';
-      evalActiveRun.value = { run_id: data.run_id, status: 'pending' };
+      const activeState = { run_id: data.run_id, status: 'pending' };
+      evalActiveRun.value = activeState;
+      sessionStorage.setItem('evalActiveRun', JSON.stringify(activeState));
+      startEvalPoll(data.run_id);
       // Refresh run list so the new run appears immediately
       await fetchEvalRuns();
     } catch (exc) {

--- a/ollama_queue/dashboard/spa/src/store.js
+++ b/ollama_queue/dashboard/spa/src/store.js
@@ -73,6 +73,7 @@ export function startEvalPoll(runId) {
       sessionStorage.setItem('evalActiveRun', JSON.stringify(data));
       if (['complete', 'failed', 'cancelled'].includes(data.status)) {
         stopEvalPoll();
+        fetchEvalRuns(); // refresh history table so final metrics appear immediately
       }
     } catch (e) {
       console.error('evalPoll failed:', e);
@@ -171,6 +172,9 @@ export async function triggerEvalRun(body) {
 // Decision it drives: stops live progress polling and refreshes run history
 export async function cancelEvalRun(runId) {
   await fetch(`${API}/eval/runs/${runId}`, { method: 'DELETE' });
+  stopEvalPoll();
+  evalActiveRun.value = null;
+  sessionStorage.removeItem('evalActiveRun');
   await fetchEvalRuns();
 }
 


### PR DESCRIPTION
## Summary

- **Progress bar stuck at 0%** — API returned `pct_complete`/`judged` but frontend destructured `pct`/`completed`; fixed by adding aliased fields to the progress endpoint
- **Stage label always "Working…"** — frontend checked `stage === 'generate'`/`'judge'` but DB stores `'generating'`/`'judging'`; fixed stage matching + status fallback
- **Per-variant bars never rendered** — `per_variant` was absent from progress response; added grouped query by variant
- **Cancel left progress panel open** — `cancelEvalRun` didn't stop polling or clear `evalActiveRun`; fixed
- **Repeat never showed progress** — `handleRepeat` didn't call `startEvalPoll`; fixed + added sessionStorage write for page-refresh resilience
- **History table stale after run completes** — `startEvalPoll` didn't call `fetchEvalRuns` on terminal status; fixed
- **Scorer selection ignored** — trigger endpoint didn't persist `judge_model` from request body; fixed

## Test plan

- [x] 535/535 tests pass (no regressions)
- [x] SPA builds clean
- [x] Service restarted and healthy
- [ ] Manual: start a run, verify progress bar moves and stage label updates
- [ ] Manual: cancel a run, verify progress panel disappears immediately
- [ ] Manual: repeat a completed run, verify live progress shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)