### PR TITLE
fix(eval): correct generate row_type 'generation' → 'generate'

### DIFF
--- a/ollama_queue/eval_engine.py
+++ b/ollama_queue/eval_engine.py
@@ -699,7 +699,7 @@ def _generate_one(
         source_item_id=str(source_item["id"]),
         target_item_id=str(source_item["id"]),
         is_same_cluster=0,
-        row_type="generation",  # distinguishes from judge rows in queries
+        row_type="generate",  # matches progress query and DB row_type='judge' convention
         principle=text,
         generation_time_s=generation_time_s,
         queue_job_id=queue_job_id,


### PR DESCRIPTION
## Summary

- Engine inserted `row_type='generation'` in `_generate_one` but the progress query, per-variant query, and all test fixtures expected `row_type='generate'`
- Result: generated count always 0 during the generate phase — progress bar stuck, completed/total showed 0/N even when generation was actively running
- Tests passed because they insert rows directly with the correct string and never exercise the engine path — classic unit isolation gap

## Root cause trace

```
_generate_one (eval_engine.py:702) → INSERT row_type='generation'
progress endpoint (api.py:1722)   → counts.get('generate', 0) → always 0
```

## Fix

One-line: `row_type="generation"` → `row_type="generate"`

## Test plan

- [x] 535/535 tests pass
- [ ] Manual: start eval run, verify generated count increments in progress panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)