### PR TITLE
fix: guard poll_interval empty-string and model None in scheduler

### DIFF
--- a/ollama_queue/api/jobs.py
+++ b/ollama_queue/api/jobs.py
@@ -268,7 +268,8 @@ def _compute_kpis_locked(db: Database) -> dict:
     # NOTE: Use raw conn query (not db.get_setting) to avoid thread-safety issues
     # when _compute_kpis is called from FastAPI worker threads.
     setting_row = conn.execute("SELECT value FROM settings WHERE key = ?", ("poll_interval_seconds",)).fetchone()
-    poll_interval = json.loads(setting_row["value"]) if setting_row else 5
+    _raw_pi = json.loads(setting_row["value"]) if setting_row else None
+    poll_interval = int(float(_raw_pi)) if _raw_pi else 5
     row = conn.execute(
         """SELECT COUNT(*) as cnt FROM health_log
            WHERE daemon_state LIKE '%paused%' AND timestamp >= ?""",

--- a/ollama_queue/scheduling/scheduler.py
+++ b/ollama_queue/scheduling/scheduler.py
@@ -350,7 +350,7 @@ class Scheduler:
         for rj in self._get_recurring_jobs():
             if not rj["enabled"]:
                 continue
-            model = rj.get("model", "")
+            model = rj.get("model") or ""
             model_vram = _estimate_model_vram(model)
 
             # Build a temporary score array to find which slots this job fires in


### PR DESCRIPTION
## Summary

Two defensive fixes for runtime TypeErrors seen in service logs.

### Fix 1: `api/jobs.py` — empty-string settings value causes TypeError on arithmetic

`poll_interval_seconds` was stored as `""` (JSON empty string) in the DB. `json.loads('""')` returns `''`. Python `int * ''` = string repetition; then `'' / 60.0` raises `TypeError: unsupported operand type(s) for /: 'str' and 'float'`.

**Fix:** `int(float(_raw_pi)) if _raw_pi else 5` — handles empty string, None, int, float, and numeric string.

### Fix 2: `scheduling/scheduler.py` — `dict.get(key, default)` doesn't use default when value is None

`rj.get('model', '')` returned `None` because the recurring job row had `model=NULL` in the DB. `sqlite3.Row` always includes all columns, so the key is never absent — only its value is `None`. Python's `dict.get(key, default)` only fires the default when the key is **absent**.

**Fix:** `rj.get('model') or ''` — handles both missing key and None value.

## Lessons Captured

- #1901: `dict.get(key, default)` returns None when key exists with value None
- #1902: JSON-serialized settings can be stored as empty string, causing TypeError on arithmetic