### PR TITLE
fix: downgrade generate-description timeout to WARNING; strip DLQ prefix chain

### DIFF
--- a/ollama_queue/api/schedule.py
+++ b/ollama_queue/api/schedule.py
@@ -107,6 +107,9 @@ def _call_generate_description(rj_id: int, name: str, tag: str | None, command: 
             db_ref.update_recurring_job(rj_id, description=description)
         else:
             _log.warning("generate-description: empty response from model for job %d", rj_id)
+    except httpx.ReadTimeout:
+        # Expected when Ollama is busy — not an error, just skip; next schedule add will retry
+        _log.warning("generate-description: Ollama timed out for recurring job %d — will retry on next trigger", rj_id)
     except Exception:
         _log.exception("generate-description failed for recurring job %s", rj_id)
 

--- a/ollama_queue/scheduling/dlq_scheduler.py
+++ b/ollama_queue/scheduling/dlq_scheduler.py
@@ -16,6 +16,15 @@ from ollama_queue.sensing.system_snapshot import classify_failure
 
 logger = logging.getLogger(__name__)
 
+_DLQ_PREFIX = "dlq-reschedule:"
+
+
+def _strip_dlq_prefix(source: str) -> str:
+    """Remove all leading 'dlq-reschedule:' prefixes so they don't chain unboundedly."""
+    while source.startswith(_DLQ_PREFIX):
+        source = source[len(_DLQ_PREFIX) :]
+    return source
+
 
 class DLQScheduler:
     """Sweeps DLQ entries and auto-reschedules into optimal time slots."""
@@ -147,7 +156,7 @@ class DLQScheduler:
                 model=entry.get("model", ""),
                 priority=entry.get("priority", 0),
                 timeout=entry.get("timeout", 600),
-                source=f"dlq-reschedule:{entry.get('source', 'unknown')}",
+                source=f"dlq-reschedule:{_strip_dlq_prefix(entry.get('source', 'unknown'))}",
                 tag=entry.get("tag"),
                 resource_profile=entry.get("resource_profile", "ollama"),
             )


### PR DESCRIPTION
## Summary

Two log noise / data quality fixes found during log review.

### Fix 1: `api/schedule.py` — generate-description ReadTimeout logged as ERROR

When Ollama is busy, `_call_generate_description` called with `httpx.Client(timeout=150)` times out. This is expected under queue load — the description will be generated on the next run. Was raising an ERROR with full traceback. Now caught separately as WARNING.

### Fix 2: `scheduling/dlq_scheduler.py` — DLQ source prefix chains unboundedly

Every reschedule prepended `dlq-reschedule:` to the source string without stripping existing prefixes. After 3 reschedule cycles: `dlq-reschedule:dlq-reschedule:dlq-reschedule:embeddings-lessons-db`. Added `_strip_dlq_prefix()` to strip all leading prefixes before prepending, keeping source as `dlq-reschedule:<original-source>`.

### Not fixed here

Exit code 28 on embedding jobs = `curl -m 120` timeout inside the `embed-project` script — the queue's `timeout=600` is fine; the script's own curl timeout is too short under load. Tracked separately.