### PR TITLE
fix(spa): convert load_avg to % before ResourceGauges, fix CPU pause thresholds

### DIFF
--- a/ollama_queue/api/health.py
+++ b/ollama_queue/api/health.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 from fastapi import APIRouter
 
 import ollama_queue.api as _api
@@ -14,4 +16,8 @@ def get_health(hours: int = 24):
     db = _api.db
     daemon_state = db.get_daemon_state()
     burst_regime = daemon_state.get("burst_regime") or "unknown"
-    return {"log": db.get_health_log(hours=hours), "burst_regime": burst_regime}
+    return {
+        "log": db.get_health_log(hours=hours),
+        "burst_regime": burst_regime,
+        "cpu_count": os.cpu_count() or 1,
+    }

--- a/ollama_queue/dashboard/spa/src/components/CurrentJob.jsx
+++ b/ollama_queue/dashboard/spa/src/components/CurrentJob.jsx
@@ -6,7 +6,7 @@ import StatusBadge from './StatusBadge.jsx';
 import ResourceGauges from './ResourceGauges.jsx';
 import EmptyState from './EmptyState.jsx';
 import { formatDuration } from '../utils/time.js';
-import { API } from '../stores';
+import { API, cpuCount } from '../stores';
 
 /**
  * What it shows: What the daemon is doing RIGHT NOW — running job name/model/elapsed time
@@ -197,7 +197,7 @@ export default function CurrentJob({ daemon, currentJob, latestHealth, settings,
           <ResourceGauges
             ram={hp.ram_pct}
             vram={hp.vram_pct}
-            load={hp.load_avg}
+            load={(hp.load_avg / (cpuCount.value || 1)) * 100}
             swap={hp.swap_pct}
             settings={settings}
           />

--- a/ollama_queue/dashboard/spa/src/components/ResourceGauges.jsx
+++ b/ollama_queue/dashboard/spa/src/components/ResourceGauges.jsx
@@ -42,17 +42,20 @@ export default function ResourceGauges({ ram, vram, load, swap, settings }) {
   const gauges = [
     { label: 'RAM',  title: GAUGE_TOOLTIPS.ram,  value: ram,  pause: s.ram_pause_pct || 85,                              resume: s.ram_resume_pct || 75 },
     { label: 'GPU',  title: GAUGE_TOOLTIPS.vram, value: vram, pause: s.vram_pause_pct || 90,                             resume: s.vram_resume_pct || 80 },
-    { label: 'CPU',  title: GAUGE_TOOLTIPS.load, value: load, pause: (s.load_pause_multiplier || 2) * 50,                resume: (s.load_resume_multiplier || 1.5) * 50 },
+    { label: 'CPU',  title: GAUGE_TOOLTIPS.load, value: load, pause: (s.load_pause_multiplier || 2) * 100,              resume: (s.load_resume_multiplier || 1.5) * 100 },
     { label: 'Swap', title: GAUGE_TOOLTIPS.swap, value: swap, pause: s.swap_pause_pct || 50,                             resume: s.swap_resume_pct || 40 },
   ];
 
   return (
     <div ref={containerRef} class="flex gap-3 flex-wrap">
       {gauges.map((g) => {
-        const pct = Math.min(100, Math.max(0, g.value ?? 0));
+        const raw = g.value ?? 0;
+        const pct = Math.min(100, Math.max(0, raw));
         let color = 'var(--accent)';
-        if (pct >= g.pause) color = 'var(--status-error)';
-        else if (pct >= g.resume) color = 'var(--status-warning)';
+        // Use raw (unclamped) value for color — CPU load can exceed 100% of one core's worth,
+        // and the bar must turn warning/error even when the bar width is capped at 100%.
+        if (raw >= g.pause) color = 'var(--status-error)';
+        else if (raw >= g.resume) color = 'var(--status-warning)';
 
         return (
           <div key={g.label} title={g.title} class="flex items-center gap-1" style="min-width: 80px; flex: 1;">

--- a/ollama_queue/dashboard/spa/src/pages/Now.jsx
+++ b/ollama_queue/dashboard/spa/src/pages/Now.jsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { useEffect } from 'preact/hooks';
 import {
-    status, queue, history, healthData, durationData, settings,
+    status, queue, history, healthData, cpuCount, durationData, settings,
     dlqCount, connectionStatus, currentTab, clearDLQ,
     scheduleJobs, fetchSchedule,
 } from '../stores';
@@ -192,7 +192,7 @@ export default function Now({ onSubmitRequest }) {
                             <ResourceGauges
                                 ram={latestHealth.ram_pct}
                                 vram={latestHealth.vram_pct}
-                                load={latestHealth.load_avg}
+                                load={(latestHealth.load_avg / (cpuCount.value || 1)) * 100}
                                 swap={latestHealth.swap_pct}
                                 settings={sett}
                             />

--- a/ollama_queue/dashboard/spa/src/stores/health.js
+++ b/ollama_queue/dashboard/spa/src/stores/health.js
@@ -6,7 +6,8 @@
 import { signal } from '@preact/signals';
 import { API } from './_shared.js';
 
-export const healthData = signal([]);     // /api/health response
+export const healthData = signal([]);     // /api/health log array
+export const cpuCount = signal(1);        // cpu_count from /api/health — used to convert raw load_avg to %
 export const durationData = signal([]);   // /api/durations response
 export const heatmapData = signal([]);    // /api/heatmap response
 export const deferredJobs = signal([]);       // /api/deferred response

--- a/ollama_queue/dashboard/spa/src/stores/index.js
+++ b/ollama_queue/dashboard/spa/src/stores/index.js
@@ -20,7 +20,7 @@ export * from './health.js';
 // ── Import individual signals/functions needed by the polling orchestrator ────
 import { status, queue, connectionStatus } from './queue.js';
 import { settings } from './settings.js';
-import { healthData, durationData, heatmapData, dlqSchedulePreview,
+import { healthData, cpuCount, durationData, heatmapData, dlqSchedulePreview,
          fetchDLQ, fetchDeferred, fetchDLQSchedulePreview, fetchModelPerformance,
          fetchPerformanceCurve } from './health.js';
 import { history } from './queue.js';
@@ -88,7 +88,7 @@ async function _fetchNonRealtime() {
             fetch(`${API}/heatmap`),
             fetch(`${API}/history`),
         ]);
-        if (hResp.ok) { const d = await hResp.json(); healthData.value = Array.isArray(d) ? d : (d.log ?? []); }
+        if (hResp.ok) { const d = await hResp.json(); healthData.value = Array.isArray(d) ? d : (d.log ?? []); if (d.cpu_count) cpuCount.value = d.cpu_count; }
         if (durResp.ok) durationData.value = await durResp.json();
         if (heatResp.ok) heatmapData.value = await heatResp.json();
         if (histResp.ok) history.value = await histResp.json();

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -116,6 +116,16 @@ def test_health_includes_burst_regime(client):
     assert data["burst_regime"] in {"unknown", "subcritical", "moderate", "warning", "critical"}
 
 
+def test_health_includes_cpu_count(client):
+    """GET /api/health includes cpu_count for load gauge percentage conversion."""
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "cpu_count" in data
+    assert isinstance(data["cpu_count"], int)
+    assert data["cpu_count"] >= 1
+
+
 def test_get_durations(client):
     resp = client.get("/api/durations")
     assert resp.status_code == 200


### PR DESCRIPTION
Fixes #105

## Root cause
`ResourceGauges` received raw Unix `load_avg` (e.g. 1.5) and treated it as a 0–100% percentage — showing 1.5% on a loaded 4-core machine. The CPU pause/resume thresholds used `multiplier × 50` with no CPU count basis.

## Changes
- **`api/health.py`**: Add `cpu_count: os.cpu_count()` to `GET /api/health` response
- **`stores/health.js`**: Add `cpuCount` signal (default 1)
- **`stores/index.js`**: Parse `cpu_count` from health response into `cpuCount` signal
- **`Now.jsx` + `CurrentJob.jsx`**: Pass `(load_avg / cpuCount) × 100` to `ResourceGauges`
- **`ResourceGauges.jsx`**: Fix CPU `pause`/`resume` to `multiplier × 100`; use raw unclamped value for color comparison so overloaded bars (>100%) correctly turn warning/error
- **`tests/test_api.py`**: `test_health_includes_cpu_count` — assert `cpu_count ≥ 1` in response

## Test result
1677 passed, 1 skipped