### PR TITLE
fix(sensing): read cpu_count from /proc/cpuinfo, route through HealthMonitor

### DIFF
--- a/ollama_queue/api/health.py
+++ b/ollama_queue/api/health.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-import os
-
 from fastapi import APIRouter
 
 import ollama_queue.api as _api
+from ollama_queue.sensing import HealthMonitor
 
 router = APIRouter()
+
+# CPU count is a hardware constant — read once at startup via HealthMonitor
+# (same path used by the daemon's pause/resume logic)
+_CPU_COUNT = HealthMonitor().get_cpu_count()
 
 
 @router.get("/api/health")
@@ -19,5 +22,5 @@ def get_health(hours: int = 24):
     return {
         "log": db.get_health_log(hours=hours),
         "burst_regime": burst_regime,
-        "cpu_count": os.cpu_count() or 1,
+        "cpu_count": _CPU_COUNT,
     }

--- a/ollama_queue/sensing/health.py
+++ b/ollama_queue/sensing/health.py
@@ -11,7 +11,6 @@ recovered), or yield (a human is actively using Ollama right now)?
 from __future__ import annotations
 
 import logging
-import os
 import subprocess
 import time
 
@@ -54,8 +53,13 @@ class HealthMonitor:
             return 0.0
 
     def get_cpu_count(self) -> int:
-        """Return number of CPUs."""
-        return os.cpu_count() or 1
+        """Count logical CPUs from /proc/cpuinfo (one 'processor' entry per logical CPU)."""
+        try:
+            with open("/proc/cpuinfo") as f:
+                count = sum(1 for line in f if line.startswith("processor"))
+            return count or 1
+        except OSError:
+            return 1
 
     def get_vram_pct(self) -> float | None:
         """Query nvidia-smi for VRAM usage percentage, with TTL cache.


### PR DESCRIPTION
Follow-up to #110.

## Changes
- **`sensing/health.py`**: `get_cpu_count()` now reads `/proc/cpuinfo` (counts `processor` entries) — consistent with `get_load_avg() → /proc/loadavg` and `get_ram_pct() → /proc/meminfo`. Removes `os.cpu_count()` and the `os` import entirely.
- **`api/health.py`**: Imports `HealthMonitor` and caches `cpu_count` at module startup instead of calling `os.cpu_count()` directly — all hardware reads now go through the `sensing` layer.

## Result
All 37 health + API tests pass.